### PR TITLE
working keyboard shortcuts, compare task, and back button for both classify and compare

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ python3 flask_server/image_comparator/utils/makeCompareList.py <imageSetName> <l
 ```
 
 ```bash
-python3 flask_server/image_comparator/utils/makeCompareList.py sample_data sample_dataCompareList
-python3 flask_server/image_comparator/utils/makeCompareList.py sample_data sample_dataCompareList 10
+python3 flask_server/image_comparator/utils/makeCompareList.py sample_data sample_data_CompareList
+python3 flask_server/image_comparator/utils/makeCompareList.py sample_data sample_data_CompareList 10
 ```
 
 ### Image-Classifier
@@ -181,15 +181,17 @@ python3 flask_server/image_comparator/utils/makeTask.py <user> <image-list-name>
 
 Ex:
 ```bash
-python3 flask_server/image_comparator/utils/makeTask.py Benjamin sample_data_ClassifyList classify 1 test_description_sample_data
-python3 flask_server/image_comparator/utils/makeTask.py Rob sample_data_ClassifyList classify 1 test_description_sample_data
-python3 flask_server/image_comparator/utils/makeTask.py Bill sample_data_ClassifyList classify 1 test_description_sample_data
+
+python3 flask_server/image_comparator/utils/makeTask.py Benjamin sample_data_CompareList compare 1 test_description_sample_data
+python3 flask_server/image_comparator/utils/makeTask.py Rob sample_data_CompareList compare 1 test_description_sample_data
+python3 flask_server/image_comparator/utils/makeTask.py Bill sample_data_CompareList compare 1 test_description_sample_data
 ```
 
 Ex:
 ```bash
-python3 flask_server/image_comparator/utils/makeTask.py Benjamin sample_data_ClassifyList classify 1
-python3 flask_server/image_comparator/utils/makeTask.py Benjamin sample_data_ClassifyList classify 1 test_description
+python3 flask_server/image_comparator/utils/makeTask.py Benjamin sample_data_ClassifyList classify 1 test_description_sample_data
+python3 flask_server/image_comparator/utils/makeTask.py Rob sample_data_ClassifyList classify 1 test_description_sample_data
+python3 flask_server/image_comparator/utils/makeTask.py Bill sample_data_ClassifyList classify 1 test_description_sample_data
 ```
 
 Ex:

--- a/flask_server/image_comparator/routes_blueprint.py
+++ b/flask_server/image_comparator/routes_blueprint.py
@@ -469,7 +469,10 @@ def reset_to_previous_result(app):
         current_app.config['DNS'], current_app.config["DB_PORT"], current_app.config["IMAGES_DB"])
 
     # get old result
-    view = f"_design/basic_views/_view/results{app.capitalize()}?key=\"{currentTask['user']}\""
+    if app.capitalize() == "Compare":
+        view = f"_design/basic_views/_view/results{app.capitalize()}?key=[\"{currentTask['user']}\",\"{currentTask['list_name']}\"]"
+    else:
+        view = f"_design/basic_views/_view/results{app.capitalize()}_userList?key=[\"{currentTask['user']}\",\"{currentTask['list_name']}\"]"
     url = f"{base}/{view}"
     response = check_if_admin_party_then_make_request(url)
     all_results = json.loads(response.content.decode('utf-8'))

--- a/flask_server/image_comparator/static/js/basic_views.json
+++ b/flask_server/image_comparator/static/js/basic_views.json
@@ -45,8 +45,11 @@
     "resultsClassify": {
       "map": "function(doc) {\n  if (doc.type===\"classifyResult\")\n    emit(doc.user, doc);\n}"
     },
+    "resultsClassify_userList": {
+      "map": "function(doc) {\n  if (doc.type===\"classifyResult\")\n    emit([doc.user, doc.task_list_name], doc);\n}"
+    },
     "resultsCompare": {
-      "map": "function(doc) {if (doc.type===\"compareResult\")\n  emit(doc.user, doc);\n}"
+      "map": "function(doc) {if (doc.type===\"compareResult\")\n  emit([doc.user, doc.task_list_name], doc);\n}"
     },
     "resultsGrid": {
       "map": "function(doc) {\n  if (doc.type===\"gridResult\")\n    emit(doc.user, doc);\n}"

--- a/flask_server/image_comparator/static/js/default.js
+++ b/flask_server/image_comparator/static/js/default.js
@@ -271,4 +271,25 @@ function TaskFeeder(config_obj) {
     })
   };
 
+  this.resetToPreviousTaskId = function () {
+    TF = this;
+    if (TF.currentTask.current_idx === 0) {
+        alert('You are on the first task, cannot go back.')
+    } else {
+        TF.disableButtons();
+        $.ajax({
+            url: this.url_reset_to_previous_result,
+            type: 'POST',
+            data: JSON.stringify(this.currentTask),
+            headers: { 'Content-Type': 'application/json' },
+            success: (response) => {
+                TF.OnSetUser(TF.user)
+            },
+            error: (response) => {
+                console.log('resetToPreviousClassification error!')
+            },
+        });
+    }
+  };
+
 }

--- a/flask_server/image_comparator/static/js/image_class.js
+++ b/flask_server/image_comparator/static/js/image_class.js
@@ -104,18 +104,18 @@ function init_app() {
                     else if (event.keyCode == 52) {
                         alert('4 was pressed');
                     }
-                } else if (TF.keyboardShortcuts === true && document.getElementById("option1").disabled === false) {
+                } else if (TF.keyboardShortcuts === true && document.getElementById("no_motion").disabled === false) {
                     if (event.keyCode == 49) {
-                        $("#option1").click()
+                        $("#no_motion").click()
                     }
                     else if (event.keyCode == 50) {
-                        $("#option2").click()
+                        $("#mild_motion").click()
                     }
                     else if (event.keyCode == 51) {
-                        $("#option3").click()
+                        $("#moderate_motion").click()
                     }
                     else if (event.keyCode == 52) {
-                        $("#option4").click()
+                        $("#severe_motion").click()
                     }
                 }
             }

--- a/flask_server/image_comparator/templates/image_class.html
+++ b/flask_server/image_comparator/templates/image_class.html
@@ -140,10 +140,10 @@
                             images. Otherwise you can click with your mouse. Controls are below.</p>
                         <p>***************</p>
                         <p>Number keys enabled (practice mode "Off"):</p>
-                        <p>* Number 1: option1</p>
-                        <p>* Number 2: option2</p>
-                        <p>* Number 3: option3</p>
-                        <p>* Number 4: option4</p>
+                        <p>* Number 1: no motion</p>
+                        <p>* Number 2: mild motion</p>
+                        <p>* Number 3: moderate motion</p>
+                        <p>* Number 4: severe motion</p>
                         <p>***************</p>
 
                         <hr>
@@ -193,13 +193,13 @@
             onclick="ClassifyTaskFeeder.classifySubmit(this)">no motion</button>
         <br>
         <button type="button" class="btn btn-primary" id="mild_motion"
-            onclick="ClassifyTaskFeeder.classifySubmit(this)">mild_motion</button>
+            onclick="ClassifyTaskFeeder.classifySubmit(this)">mild motion</button>
         <br>
         <button type="button" class="btn btn-primary" id="moderate_motion"
-            onclick="ClassifyTaskFeeder.classifySubmit(this)">moderate_motion</button>
+            onclick="ClassifyTaskFeeder.classifySubmit(this)">moderate motion</button>
         <br>
         <button type="button" class="btn btn-primary" id="severe_motion"
-            onclick="ClassifyTaskFeeder.classifySubmit(this)">severe_motion</button>
+            onclick="ClassifyTaskFeeder.classifySubmit(this)">severe motion</button>
         <hr>
         <button type="button" class="btn btn-danger" id="previousClassification"
             onclick="ClassifyTaskFeeder.resetToPreviousClassification(this)">Go

--- a/flask_server/image_comparator/templates/two_image.html
+++ b/flask_server/image_comparator/templates/two_image.html
@@ -114,6 +114,11 @@
 
   <!-- Button trigger modal -->
   <button type="button" data-toggle="modal" data-target="#Instructions">Instructions</button>
+  <!-- Back Button -->
+  <button id="previousCompare" type="button" class="btn btn-danger" onclick="CompareTaskFeeder.resetToPreviousTaskId()" style="color: black">
+    <strong>Go Back One</strong>
+  </button>
+
   <!-- Modal -->
   <div class="modal fade" id="Instructions" tabindex="-1" role="dialog" aria-labelledby="InstructionsLabel"
     aria-hidden="true">


### PR DESCRIPTION
Fixes:
- keyboard shortcuts for classify need button names e.g. option1->no_motion
- making README makeCompareList and makeTask instructions consistent
- fixed back button for classify
- added back button for compare

Minor:
- tidied up no/mild/moderate/severe website display labels